### PR TITLE
Replaced language referencing 'continue to the app'

### DIFF
--- a/build.html
+++ b/build.html
@@ -4,7 +4,7 @@
   <div class="state" v-bind:class="{ start: loading, past: verifyCode || confirmation, present: auth, 'has-code': storedEmail}" data-state="auth">
     <form v-on:submit.prevent="sendValidation">
       <h2 class="aligncenter">Authentication</h2>
-      <p>Authenticate your email address below to gain access to the app.</p>
+      <p>Authenticate your email address below to gain access to proceed.</p>
       <div class="form-group" v-bind:class="{ 'has-error': emailError}">
         <input type="email" v-model="email" name="verify-email" class="form-control verify_email" placeholder="Enter your email">
       </div>
@@ -42,7 +42,7 @@
 
   <div class="state" v-bind:class="{ past: verifyCode, present: confirmation, future: loading || auth || verifyCode }" data-state="confirmation">
     <h2>Welcome</h2>
-    <p>You have been authenticated and you can now continue to the app.</p>
+    <p>You have been authenticated and you can now proceed.</p>
     <button class="btn btn-primary lock_continue" v-on:click="redirect">Continue</button>
   </div>
 </div>
@@ -50,7 +50,7 @@
 <div class="content-wrapper placeholder">
   <div class="state present" data-state="auth">
     <h2 class="aligncenter">Authentication</h2>
-    <p>Authenticate your email address below to gain access to the app.</p>
+    <p>Authenticate your email address below to proceed.</p>
     <div class="form-group">
       <input type="email" name="verify-email" class="form-control verify_email" placeholder="Enter your email">
     </div>

--- a/build.html
+++ b/build.html
@@ -15,7 +15,7 @@
         <p class="email-error text-danger">\{{ securityError }}</p>
       </template>
       <button class="btn btn-primary verify-identity" v-bind:class="{ disabled: disableButton }" type="submit">\{{ sendValidationLabel }}</button>
-      <button v-if="storedEmail" v-on:click="showVerify" class="btn btn-link have-code">I have a verification code.</button>
+      <button v-if="storedEmail" v-on:click="showVerify" class="btn btn-link have-code">I have a verification code</button>
     </form>
   </div>
 

--- a/build.html
+++ b/build.html
@@ -3,8 +3,8 @@
   <div class="verfication-offline">Your device is offline</div>
   <div class="state" v-bind:class="{ start: loading, past: verifyCode || confirmation, present: auth, 'has-code': storedEmail}" data-state="auth">
     <form v-on:submit.prevent="sendValidation">
-      <h2 class="aligncenter">Authentication</h2>
-      <p>Authenticate your email address below to gain access to proceed.</p>
+      <h2 class="aligncenter">Verification</h2>
+      <p>Verify your email address below to gain access.</p>
       <div class="form-group" v-bind:class="{ 'has-error': emailError}">
         <input type="email" v-model="email" name="verify-email" class="form-control verify_email" placeholder="Enter your email">
       </div>
@@ -15,7 +15,7 @@
         <p class="email-error text-danger">\{{ securityError }}</p>
       </template>
       <button class="btn btn-primary verify-identity" v-bind:class="{ disabled: disableButton }" type="submit">\{{ sendValidationLabel }}</button>
-      <button v-if="storedEmail" v-on:click="showVerify" class="btn btn-link have-code">I have an authentication code</button>
+      <button v-if="storedEmail" v-on:click="showVerify" class="btn btn-link have-code">I have a verification code.</button>
     </form>
   </div>
 
@@ -23,38 +23,37 @@
     <form v-on:submit.prevent="validate">
       <h2>Verify your email address</h2>
       <template v-if="type === 'email'">
-          <p>Enter the authentication code that was sent to <span class="input-email">\{{ storedEmail }}</span>.</p>
+          <p>Enter the verification code that was sent to <span class="input-email">\{{ storedEmail }}</span>.</p>
         </template>
       <template v-if="type === 'sms'">
-          <p>Enter the authentication code that was sent to the phone number associated with <span class="input-email">\{{ storedEmail }}</span>.</p>
+          <p>Enter the verification code that was sent to the phone number associated with <span class="input-email">\{{ storedEmail }}</span>.</p>
         </template>
       <div class="form-group input-wrapper" v-bind:class="{ 'has-error': codeError}">
-        <input type="text" v-model="code" class="verify_pin form-control" placeholder="Enter authentication code">
+        <input type="text" v-model="code" class="verify_pin form-control" placeholder="Enter verification code">
         <span v-on:click="back" class="fa fa-chevron-left back"></span>
       </div>
-      <p class="pin-error text-danger">You entered the wrong authentication code or it might have expired.
-        <br>Try again or tap <i>Resend authentication code</i>.</p>
+      <p class="pin-error text-danger">You entered the wrong verification code or it might have expired.
+        <br>Try again or tap <i>Resend verification code</i>.</p>
       <button class="btn btn-primary verify-code" type="submit">Verify</button>
-      <button v-on:click="resendCode" class="btn btn-link resend-code">Resend authentication code</button>
-      <p class="pin-resent text-success">A new authentication code was sent to your email.</p>
+      <button v-on:click="resendCode" class="btn btn-link resend-code">Resend verification code</button>
+      <p class="pin-resent text-success">A new verification code was sent to your email.</p>
     </form>
   </div>
 
   <div class="state" v-bind:class="{ past: verifyCode, present: confirmation, future: loading || auth || verifyCode }" data-state="confirmation">
-    <h2>Welcome</h2>
-    <p>You have been authenticated and you can now proceed.</p>
+    <p>You have been verified and you can now proceed.</p>
     <button class="btn btn-primary lock_continue" v-on:click="redirect">Continue</button>
   </div>
 </div>
 {{else}}
 <div class="content-wrapper placeholder">
   <div class="state present" data-state="auth">
-    <h2 class="aligncenter">Authentication</h2>
-    <p>Authenticate your email address below to proceed.</p>
+    <h2 class="aligncenter">Verification</h2>
+    <p>Verify your email address below to proceed.</p>
     <div class="form-group">
       <input type="email" name="verify-email" class="form-control verify_email" placeholder="Enter your email">
     </div>
-    <button class="btn btn-primary disabled" disabled>Authenticate</button>
+    <button class="btn btn-primary disabled" disabled>Continue</button>
   </div>
 </div>
 {{/if}}


### PR DESCRIPTION
Users sometimes use authentication components deeper within the app, such as to protect certain sections of an app. This phrasing is too specific to make sense for these eventualities. This adjustment makes the phrasing more generalized.