### PR TITLE
Redirect should default to fade animation

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -13,7 +13,7 @@ if (!data.action) {
   data.action = {
     action: 'screen',
     page: '',
-    transition: 'slide.left',
+    transition: 'fade',
     options: {
       hideAction: true
     }


### PR DESCRIPTION
@squallstar @tonytlwu 

**Fixed behavior**:
Changed default value to fade.

ref https://github.com/Fliplet/fliplet-studio/issues/1658

![fade-demo](https://user-images.githubusercontent.com/52824207/62296683-4482aa80-b478-11e9-9ec3-9df674dbbf3c.gif)
