### PR TITLE
When user enters email, input for verification code will be focused automatically

### DIFF
--- a/build.html
+++ b/build.html
@@ -29,7 +29,7 @@
           <p>Enter the verification code that was sent to the phone number associated with <span class="input-email">\{{ storedEmail }}</span>.</p>
         </template>
       <div class="form-group input-wrapper" v-bind:class="{ 'has-error': codeError}">
-        <input type="tel" v-model="code" class="verify_pin form-control" placeholder="Enter verification code">
+        <input type="tel" v-model="code" class="verify_pin form-control" ref="verificationCode" placeholder="Enter verification code">
         <span v-on:click="back" class="fa fa-chevron-left back"></span>
       </div>
       <p class="pin-error text-danger">You entered the wrong verification code or it might have expired.

--- a/js/build.js
+++ b/js/build.js
@@ -191,6 +191,7 @@ Fliplet().then(function() {
           vmData.auth = false;
           vmData.verifyCode = true;
           vmData.emailError = false;
+          this.$refs.verificationCode.select();
         },
         haveCode: function() {
           Fliplet.Analytics.trackEvent({


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#2571

## Description
Added ref for verification input. After the verification window opens, verification input will be focused automatically

## Screenshots/screencasts
![verification demo](https://user-images.githubusercontent.com/52824207/65489579-19cf3400-deb4-11e9-8caa-ddd9b90b41f9.gif)

## Backward compatibility
This change is fully backward compatible.