### PR TITLE
When a user press cancel button in email template he will close only email template, not all interface

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -44,6 +44,10 @@ var validationProvider = Fliplet.Widget.open('com.fliplet.validation-manager', {
   }
 });
 
+Fliplet.Widget.onCancelRequest(function() {
+  validationProvider.forwardCancelRequest();
+});
+
 // 1. Fired from Fliplet Studio when the external save button is clicked
 Fliplet.Widget.onSaveRequest(function() {
   $('form').submit();


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6137

## Description
When a user press cancel button in email template he will close only email template, not all interface

## Screenshots/screencasts
https://share.getcloudapp.com/2NuBnZYZ

## Backward compatibility

This change is fully backward compatible.

## Notes
This is PR works alongside this [one](https://github.com/Fliplet/fliplet-widget-validation-manager/pull/16).

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 