### PR TITLE
DEV-1096 [FIX] Auto-redirect verified users on email verification widget

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -314,7 +314,7 @@ Fliplet.Widget.instance('email-verification', function(data) {
 
         // Check if user is already verified
         if (!Fliplet.Env.get('disableSecurity')) {
-          Fliplet.User.getCachedSession()
+          Fliplet.User.getCachedSession({ force: true })
             .then(function(session) {
               if (!session || !session.accounts) {
                 return Promise.reject(T('widgets.login.emailVerification.errors.sessionNotFound'));
@@ -347,6 +347,10 @@ Fliplet.Widget.instance('email-verification', function(data) {
               ]);
             })
             .then(function() {
+              if (typeof data.action === 'undefined') {
+                return Promise.reject(T('widgets.login.emailVerification.errors.redirectMissing'));
+              }
+
               var navigate = Fliplet.Navigate.to(data.action);
 
               if (typeof navigate === 'object' && typeof navigate.then === 'function') {

--- a/translation.json
+++ b/translation.json
@@ -29,7 +29,8 @@
         "errors": {
           "emailInvalid": "Please enter a valid email.",
           "emailVerificationFailed": "Error verifying email",
-          "sessionNotFound": "Login session not found"
+          "sessionNotFound": "Login session not found",
+          "redirectMissing": "Screen redirect is not set up."
         }
       }
     }


### PR DESCRIPTION
Ticket: https://weboo.atlassian.net/browse/DEV-1096

## Summary
- Force a fresh session fetch in the email-verification widget so a stale or empty local cache no longer blocks the auto-redirect for users who are already verified against the configured data source.
- Guard `Fliplet.Navigate.to(data.action)` against an undefined redirect target so misconfigured widgets surface through the existing catch handler instead of failing silently.
- Mirrors the proven pattern in `fliplet-widget-login-data-source` (`js/build.js:125`, `js/build.js:171-173`).

## Test plan
Full scenarios and expected results are documented in [DEV-1096](https://weboo.atlassian.net/browse/DEV-1096).

- [ ] **TC1** Cached session present, redirect configured → immediate redirect to `data.action`.
- [ ] **TC2** No session / guest visitor → auth form shown, no console errors.
- [ ] **TC3** `data.action` undefined → `redirectMissing` console warn, no crash, form shown.
- [ ] **TC4** Regression: `disableSecurity` env flag → auto-redirect block skipped.
- [ ] **TC5** Regression: `sendValidation`, `verifyCode`, resend-code, and PS-1590 accordion/container visibility still work.
- [ ] **TC6** Network failure during forced session fetch → graceful fallback to form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-1096]: https://weboo.atlassian.net/browse/DEV-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ