### PR TITLE
PS-1990 [FIX] Refresh cached session after OTP validate to break verification loop

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -209,6 +209,11 @@ Fliplet.Widget.instance('email-verification', function(data) {
                         return Fliplet.Hooks.run('onUserVerified', {
                           entry: entry
                         });
+                      }).then(function() {
+                        // Refresh the cached session so screens that read
+                        // Fliplet.Session.get() immediately after the post-validate
+                        // navigation see the logged-in state (PS-1990).
+                        return Fliplet.User.getCachedSession({ force: true });
                       });
                     })
                     .then(function() {


### PR DESCRIPTION
## Summary
- Fixes [PS-1990](https://weboo.atlassian.net/browse/PS-1990) — Ramer & Moore client report of an Email Verification → Browse Files → Email Verification redirect loop after a successful OTP entry.
- Root cause: the post-validate path in `validate()` (`js/build.js`) calls `Fliplet.Navigate.to(data.action)` (via `vmData.confirmation = true` → `redirect()` with a 1s timeout) without first refreshing the session cache. Downstream screens that call `Fliplet.Session.get()` on mount (here, `fm-auth.js checkSession()` on Browse Files) can read a stale cache with no `session.entries.dataSource` and bounce the user back to the login screen.
- Fix: chain `Fliplet.User.getCachedSession({ force: true })` after `Fliplet.Hooks.run('onUserVerified', …)` so the outer `.then` that fires `authenticate_pass` and flips `vmData.confirmation` only runs after the session cache has refreshed.

The widget's own `mounted()` "already verified" branch already calls `getCachedSession({ force: true })` for the same reason — the OTP-success path was missing this step.

## Evidence from the affected app
- Audit logs (May 29): 4 cycles of `authenticate_pass` + `user.login` followed by `pageView Email Verification` 3–5s later, with no `pageView Browse Files` in between. Matches the 1s `setTimeout` + navigation + `checkSession()` redirect.
- Worked on May 27 (first attempt landed cleanly within 4s) — race timing is sensitive to network/server latency, which is why CS could not reproduce.

## Test plan
- [ ] Stand up a Fliplet app with an OTP screen using this widget and a downstream screen that calls `Fliplet.Session.get()` (or `FM.auth.checkSession()` equivalent) on mount.
- [ ] Enter a valid email → enter the OTP → confirm the user lands on the downstream screen and stays there (no bounce back to OTP).
- [ ] Repeat under slow-network conditions (e.g. Chrome devtools "Slow 3G") to exercise the original race window.
- [ ] Regression: confirm the "already verified" auto-redirect on page load still works (this path is unchanged).
- [ ] Regression: confirm an invalid OTP still shows the error and does not navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1990]: https://weboo.atlassian.net/browse/PS-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ