### PR TITLE
PS-1990 [FIX] Refresh cached session after OTP validate to prevent ve…

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -209,6 +209,11 @@ Fliplet.Widget.instance('email-verification', function(data) {
                         return Fliplet.Hooks.run('onUserVerified', {
                           entry: entry
                         });
+                      }).then(function() {
+                        // Refresh the cached session so screens that read
+                        // Fliplet.Session.get() immediately after the post-validate
+                        // navigation see the logged-in state (PS-1990).
+                        return Fliplet.User.getCachedSession({ force: true });
                       });
                     })
                     .then(function() {


### PR DESCRIPTION
…rification loop (#64)

The post-validate path was navigating to the success screen before the Fliplet session cache was refreshed from the server, so any screen that read Fliplet.Session.get() on mount (e.g. an fm-auth checkSession guard) could see no session.entries.dataSource and bounce the user back to the Email Verification screen, producing the loop reported in PS-1990.

Chain Fliplet.User.getCachedSession({ force: true }) after the onUserVerified hook so the session cache is refreshed before authenticate_pass fires and vmData.confirmation flips, which is what triggers the Fliplet.Navigate.to(data.action) redirect.